### PR TITLE
Added change to accessControlHeaders function, to be used for platform core and notifications

### DIFF
--- a/lib/accessControlHeaders.js
+++ b/lib/accessControlHeaders.js
@@ -19,7 +19,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-module.exports = () => (req, res, next) => {
+module.exports = (req, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');
   res.header(
     'Access-Control-Allow-Headers',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-middleware",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-middleware",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Common middleware for Node.js apps",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/accessControlHeaders.spec.js
+++ b/tests/unit/accessControlHeaders.spec.js
@@ -27,11 +27,6 @@ describe('Access Control Headers middleware', () => {
     header: jest.fn(),
   };
   const next = jest.fn();
-  let middleware;
-
-  beforeEach(() => {
-    middleware = accessControlHeaders();
-  });
 
   afterEach(() => {
     res.header.mockClear();
@@ -43,12 +38,12 @@ describe('Access Control Headers middleware', () => {
   });
 
   it('returns a middlware function', () => {
-    expect(typeof middleware).toBe('function');
-    expect(middleware).toHaveLength(3);
+    expect(typeof accessControlHeaders).toBe('function');
+    expect(accessControlHeaders).toHaveLength(3);
   });
 
   it('sets headers', () => {
-    middleware(req, res, next);
+    accessControlHeaders(req, res, next);
 
     expect(res.header.mock.calls).toEqual([
       ['Access-Control-Allow-Origin', '*'],
@@ -60,7 +55,7 @@ describe('Access Control Headers middleware', () => {
   });
 
   it('calls next', () => {
-    middleware(req, res, next);
+    accessControlHeaders(req, res, next);
 
     expect(next).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
Refactor to accesControlHeaders function. Needs to be used in platform-core and platform-notifications to avoid code duplication.